### PR TITLE
Add bounds check to Severity.String()

### DIFF
--- a/severity.go
+++ b/severity.go
@@ -18,6 +18,9 @@ const (
 var severityNames = []string{"DEBUG", "INFO", "WARN", "ERROR"}
 
 func (s Severity) String() string {
+	if int(s) < 0 || int(s) >= len(severityNames) {
+		return "UNKNOWN"
+	}
 	return severityNames[s]
 }
 


### PR DESCRIPTION
This fixes a panic in a test case in vulcand where it sets `Severity(-1)` in a test case