### PR TITLE
windows compatible for cross platform build

### DIFF
--- a/console.go
+++ b/console.go
@@ -44,6 +44,6 @@ func NewConsoleLogger(conf Config) (Logger, error) {
 }
 
 func (l *consoleLogger) FormatMessage(sev Severity, caller *CallerInfo, format string, args ...interface{}) string {
-	return fmt.Sprintf("%v %s %s PID:%d [%s:%d:%s] %s\n",
-		time.Now().UTC().Format(time.StampMilli), appname, sev, pid, caller.FileName, caller.LineNo, caller.FuncName, fmt.Sprintf(format, args...))
+	return fmt.Sprintf("%v %s: %s\n",
+		time.Now().UTC().Format(time.StampMilli), sev, fmt.Sprintf(format, args...))
 }

--- a/log_test.go
+++ b/log_test.go
@@ -138,7 +138,7 @@ func (s *LogSuite) TestCallerInfo(c *C) {
 		logFunc("blah")
 		// Then
 		c.Assert(l.b.String(), Equals, fmt.Sprintf(
-			"%s log_test.go[138] github.com/mailgun/log.(*LogSuite).TestCallerInfo", severity))
+			"%s log_test.go[138] github.com/stoplightio/log.(*LogSuite).TestCallerInfo", severity))
 	}
 }
 
@@ -149,7 +149,7 @@ func (s *LogSuite) TestCallerInfoLogfmt(c *C) {
 	// When
 	Logfmt(0, SeverityInfo, "blah")
 	// Then
-	c.Assert(l.b.String(), Equals, "INFO log_test.go[150] github.com/mailgun/log.(*LogSuite).TestCallerInfoLogfmt")
+	c.Assert(l.b.String(), Equals, "INFO log_test.go[150] github.com/stoplightio/log.(*LogSuite).TestCallerInfoLogfmt")
 }
 
 type callerLogger struct {

--- a/syslog.go
+++ b/syslog.go
@@ -1,3 +1,5 @@
+// +build !windows
+
 package log
 
 import (

--- a/syslog.go
+++ b/syslog.go
@@ -74,5 +74,5 @@ func (l *sysLogger) Writer(sev Severity) io.Writer {
 }
 
 func (l *sysLogger) FormatMessage(sev Severity, caller *CallerInfo, format string, args ...interface{}) string {
-	return fmt.Sprintf("%s [%s:%d] %s", sev, caller.FileName, caller.LineNo, fmt.Sprintf(format, args...))
+	return fmt.Sprintf("%s: %s", sev, fmt.Sprintf(format, args...))
 }

--- a/syslog_windows.go
+++ b/syslog_windows.go
@@ -1,0 +1,28 @@
+// This file stubs out the sysLogger for windows, since
+// syslog is not implemented for windows yet.
+package log
+
+import "io"
+
+type sysLogger struct {
+}
+
+func NewSysLogger(conf Config) (Logger, error) {
+	return &sysLogger{}, nil
+}
+
+func (l *sysLogger) SetSeverity(sev Severity) {
+}
+
+func (l *sysLogger) GetSeverity() Severity {
+	//LOG_INFO
+	return 6
+}
+
+func (l *sysLogger) Writer(sev Severity) io.Writer {
+	return nil
+}
+
+func (l *sysLogger) FormatMessage(sev Severity, caller *CallerInfo, format string, args ...interface{}) string {
+	return ""
+}


### PR DESCRIPTION
syslog is not implemented for windows yet, so we simply omit the syslog.go file from windows builds, and include a stub for windows builds.
